### PR TITLE
Fix inconsistency with the paper

### DIFF
--- a/diffuseq/gaussian_diffusion.py
+++ b/diffuseq/gaussian_diffusion.py
@@ -615,7 +615,7 @@ class GaussianDiffusion:
 
         terms = {}
 
-        target = x_start_mean
+        target = x_start
         model_output = model(x_t, self._scale_timesteps(t), **model_kwargs)
         assert model_output.shape == target.shape == x_start.shape
         terms["mse"] = mean_flat((target - model_output) ** 2)


### PR DESCRIPTION
accroding to the paper, when $t>1$, the mse should be $z_0$, which is $\mathcal{N}(Emb(w^y), I)$. Here in the code, `x_start_mean` is $Emb(w^y)$ and `x_start` is the $z_0$. this pr fixes this. 